### PR TITLE
Single-Quote strings do not interpolate in ruby

### DIFF
--- a/lib/plivo.rb
+++ b/lib/plivo.rb
@@ -75,346 +75,346 @@ module Plivo
 
       ## Accounts ##
       def get_account(params={})
-          return request('GET', '/')
+          return request('GET', "/")
       end
-
+      
       def modify_account(params={})
-          return request('POST', '/', params)
+          return request('POST', "/", params)
       end
-
+      
       def get_subaccounts(params={})
-          return request('GET', '/Subaccount/')
+          return request('GET', "/Subaccount/")
       end
-
+      
       def create_subaccount(params={})
-          return request('POST', '/Subaccount/', params)
+          return request('POST', "/Subaccount/", params)
       end
-
+      
       def get_subaccount(params={})
           subauth_id = params.delete("subauth_id")
-          return request('GET', '/Subaccount/#{subauth_id}/')
+          return request('GET', "/Subaccount/#{subauth_id}/")
       end
-
+      
       def modify_subaccount(params={})
           subauth_id = params.delete("subauth_id")
-          return request('POST', '/Subaccount/#{subauth_id}/', params)
+          return request('POST', "/Subaccount/#{subauth_id}/", params)
       end
-
+      
       def delete_subaccount(params={})
           subauth_id = params.delete("subauth_id")
-          return request('DELETE', '/Subaccount/#{subauth_id}/')
+          return request('DELETE', "/Subaccount/#{subauth_id}/")
       end
-
+      
       ## Applications ##
       def get_applications(params={})
-          return request('GET', '/Application/', params)
+          return request('GET', "/Application/", params)
       end
-
+      
       def create_application(params={})
-          return request('POST', '/Application/', params)
+          return request('POST', "/Application/", params)
       end
-
+      
       def get_application(params={})
           app_id = params.delete("app_id")
-          return request('GET', '/Application/#{app_id}/')
+          return request('GET', "/Application/#{app_id}/")
       end
-
+      
       def modify_application(params={})
           app_id = params.delete("app_id")
-          return request('POST', '/Application/#{app_id}/', params)
+          return request('POST', "/Application/#{app_id}/", params)
       end
-
+      
       def delete_application(params={})
           app_id = params.delete("app_id")
-          return request('DELETE', '/Application/#{app_id}/')
+          return request('DELETE', "/Application/#{app_id}/")
       end
-
+      
       ## Numbers ##
       def get_numbers(params={})
-          return request('GET', '/Number/', params)
+          return request('GET', "/Number/", params)
       end
-
+      
       def search_numbers(params={})
-          return request('GET', '/AvailableNumber/', params)
+          return request('GET', "/AvailableNumber/", params)
       end
-
+      
       def get_number(params={})
           number = params.delete("number")
-          return request('GET', '/Number/#{number}/')
+          return request('GET', "/Number/#{number}/")
       end
-
+      
       def rent_number(params={})
           number = params.delete("number")
-          return request('POST', '/AvailableNumber/#{number}/')
+          return request('POST', "/AvailableNumber/#{number}/")
       end
-
+      
       def unrent_number(params={})
           number = params.delete("number")
-          return request('DELETE', '/Number/#{number}/')
+          return request('DELETE', "/Number/#{number}/")
       end
-
+      
       def link_application_number(params={})
           number = params.delete("number")
-          return request('POST', '/Number/#{number}/', params)
+          return request('POST', "/Number/#{number}/", params)
       end
-
+      
       def unlink_application_number(params={})
           number = params.delete("number")
           params = {"app_id" => ""}
-          return request('POST', '/Number/#{number}/', params)
+          return request('POST', "/Number/#{number}/", params)
       end
-
+      
       ## Schedule ##
       def get_scheduled_tasks(params={})
-          return request('GET', '/Schedule/')
+          return request('GET', "/Schedule/")
       end
-
+      
       def cancel_scheduled_task(params={})
           task_id = params.delete("task_id")
-          return request('DELETE', '/Schedule/#{task_id}/')
+          return request('DELETE', "/Schedule/#{task_id}/")
       end
-
+      
       ## Calls ##
       def get_cdrs(params={})
-          return request('GET', '/Call/', params)
+          return request('GET', "/Call/", params)
       end
-
+      
       def get_cdr(params={})
           record_id = params.delete('record_id')
-          return request('GET', '/Call/#{record_id}/')
+          return request('GET', "/Call/#{record_id}/")
       end
-
+      
       def get_live_calls(params={})
-          return request('GET', '/Call/', params={'status'=>'live'})
+          return request('GET', "/Call/", params={'status'=>'live'})
       end
-
+      
       def get_live_call(params={})
           call_uuid = params.delete('call_uuid')
-          return request('GET', '/Call/#{call_uuid}/', params={'status'=>'live'})
+          return request('GET', "/Call/#{call_uuid}/", params={'status'=>'live'})
       end
-
+      
       def make_call(params={})
-          return request('POST', '/Call/', params)
+          return request('POST', "/Call/", params)
       end
-
+      
       def hangup_all_calls(params={})
-          return request('DELETE', '/Call/')
+          return request('DELETE', "/Call/")
       end
-
+      
       def transfer_call(params={})
           call_uuid = params.delete('call_uuid')
-          return request('POST', '/Call/#{call_uuid}/', params)
+          return request('POST', "/Call/#{call_uuid}/", params)
       end
-
+      
       def hangup_call(params={})
           call_uuid = params.delete('call_uuid')
-          return request('DELETE', '/Call/#{call_uuid}/')
+          return request('DELETE', "/Call/#{call_uuid}/")
       end
-
+      
       def record(params={})
           call_uuid = params.delete('call_uuid')
-          return request('POST', '/Call/#{call_uuid}/Record/', params)
+          return request('POST', "/Call/#{call_uuid}/Record/", params)
       end
           
       def stop_record(params={})
           call_uuid = params.delete('call_uuid')
-          return request('DELETE', '/Call/#{call_uuid}/Record/')
+          return request('DELETE', "/Call/#{call_uuid}/Record/")
       end
-
+      
       def play(params={})
           call_uuid = params.delete('call_uuid')
-          return request('POST', '/Call/#{call_uuid}/Play/', params)
+          return request('POST', "/Call/#{call_uuid}/Play/", params)
       end
           
       def stop_play(params={})
           call_uuid = params.delete('call_uuid')
-          return request('DELETE', '/Call/#{call_uuid}/Play/')
+          return request('DELETE', "/Call/#{call_uuid}/Play/")
       end
-
+      
       def speak(params={})
           call_uuid = params.delete('call_uuid')
-          return request('POST', '/Call/#{call_uuid}/Speak/', params)
+          return request('POST', "/Call/#{call_uuid}/Speak/", params)
       end
           
       def send_digits(params={})
           call_uuid = params.delete('call_uuid')
-          return request('POST', '/Call/#{call_uuid}/DTMF/', params)
+          return request('POST', "/Call/#{call_uuid}/DTMF/", params)
       end
-
+      
       ## Calls requests ##
       def hangup_request(params={})
           request_uuid = params.delete('request_uuid')
-          return request('DELETE', '/Request/#{request_uuid}/')
+          return request('DELETE', "/Request/#{request_uuid}/")
       end
-
+      
       ## Conferences ##
       def get_live_conferences(params={})
-          return request('GET', '/Conference/', params)
+          return request('GET', "/Conference/", params)
       end
-
+      
       def hangup_all_conferences(params={})
-          return request('DELETE', '/Conference/')
+          return request('DELETE', "/Conference/")
       end
-
+      
       def get_live_conference(params={})
           conference_name = params.delete('conference_name')
-          return request('GET', '/Conference/#{conference_name}/', params)
+          return request('GET', "/Conference/#{conference_name}/", params)
       end
-
+      
       def hangup_conference(params={})
           conference_name = params.delete('conference_name')
-          return request('DELETE', '/Conference/#{conference_name}/')
+          return request('DELETE', "/Conference/#{conference_name}/")
       end
-
+      
       def hangup_member(params={})
           conference_name = params.delete('conference_name')
           member_id = params.delete('member_id')
-          return request('DELETE', '/Conference/#{conference_name}/Member/#{member_id}/')
+          return request('DELETE', "/Conference/#{conference_name}/Member/#{member_id}/")
       end
-
+      
       def play_member(params={})
           conference_name = params.delete('conference_name')
           member_id = params.delete('member_id')
-          return request('POST', '/Conference/#{conference_name}/Member/#{member_id}/Play/', params)
+          return request('POST', "/Conference/#{conference_name}/Member/#{member_id}/Play/", params)
       end
           
       def stop_play_member(params={})
           conference_name = params.delete('conference_name')
           member_id = params.delete('member_id')
-          return request('DELETE', '/Conference/#{conference_name}/Member/#{member_id}/Play/')
+          return request('DELETE', "/Conference/#{conference_name}/Member/#{member_id}/Play/")
       end
-
+      
       def speak_member(params={})
           conference_name = params.delete('conference_name')
           member_id = params.delete('member_id')
-          return request('POST', '/Conference/#{conference_name}/Member/#{member_id}/Speak/', params)
+          return request('POST', "/Conference/#{conference_name}/Member/#{member_id}/Speak/", params)
       end
-
+      
       def deaf_member(params={})
           conference_name = params.delete('conference_name')
           member_id = params.delete('member_id')
-          return request('POST', '/Conference/#{conference_name}/Member/#{member_id}/Deaf/')
+          return request('POST', "/Conference/#{conference_name}/Member/#{member_id}/Deaf/")
       end
-
+      
       def undeaf_member(params={})
           conference_name = params.delete('conference_name')
           member_id = params.delete('member_id')
-          return request('DELETE', '/Conference/#{conference_name}/Member/#{member_id}/Deaf/')
+          return request('DELETE', "/Conference/#{conference_name}/Member/#{member_id}/Deaf/")
       end
-
+      
       def mute_member(params={})
           conference_name = params.delete('conference_name')
           member_id = params.delete('member_id')
-          return request('POST', '/Conference/#{conference_name}/Member/#{member_id}/Mute/')
+          return request('POST', "/Conference/#{conference_name}/Member/#{member_id}/Mute/")
       end
-
+      
       def unmute_member(params={})
           conference_name = params.delete('conference_name')
           member_id = params.delete('member_id')
-          return request('DELETE', '/Conference/#{conference_name}/Member/#{member_id}/Mute/')
+          return request('DELETE', "/Conference/#{conference_name}/Member/#{member_id}/Mute/")
       end
-
+      
       def kick_member(params={})
           conference_name = params.delete('conference_name')
           member_id = params.delete('member_id')
-          return request('POST', '/Conference/#{conference_name}/Member/#{member_id}/Kick/')
+          return request('POST', "/Conference/#{conference_name}/Member/#{member_id}/Kick/")
       end
-
+      
       def record_conference(params={}) 
           conference_name = params.delete('conference_name')
-          return request('POST', '/Conference/#{conference_name}/Record/', params)
+          return request('POST', "/Conference/#{conference_name}/Record/", params)
       end
-
+      
       def stop_record_conference(params={}) 
           conference_name = params.delete('conference_name')
-          return request('DELETE', '/Conference/#{conference_name}/Record/')
+          return request('DELETE', "/Conference/#{conference_name}/Record/")
       end
-
+      
       ## Recordings ##
       def get_recordings(params={})
-          return request('GET', '/Recording/', params)
+          return request('GET', "/Recording/", params)
       end
-
+      
       def get_recording(params={})
           recording_id = params.delete('recording_id')
-          return request('GET', '/Recording/#{recording_id}/')
+          return request('GET', "/Recording/#{recording_id}/")
       end
-
+      
       ## Endpoints ##
       def get_endpoints(params={})
-          return request('GET', '/Endpoint/', params)
+          return request('GET', "/Endpoint/", params)
       end
-
+      
       def create_endpoint(params={})
-          return request('POST', '/Endpoint/', params)
+          return request('POST', "/Endpoint/", params)
       end
-
+      
       def get_endpoint(params={})
           endpoint_id = params.delete('endpoint_id')
-          return request('GET', '/Endpoint/#{endpoint_id}/')
+          return request('GET', "/Endpoint/#{endpoint_id}/")
       end
-
+      
       def modify_endpoint(params={})
           endpoint_id = params.delete('endpoint_id')
-          return request('POST', '/Endpoint/#{endpoint_id}/', params)
+          return request('POST', "/Endpoint/#{endpoint_id}/", params)
       end
-
+      
       def delete_endpoint(params={})
           endpoint_id = params.delete('endpoint_id')
-          return request('DELETE', '/Endpoint/#{endpoint_id}/')
+          return request('DELETE', "/Endpoint/#{endpoint_id}/")
       end
-
+      
       ## Carriers ##
       def get_carriers(params={})
-          return request('GET', '/Carrier/', params)
+          return request('GET', "/Carrier/", params)
       end
-
+      
       def create_carrier(params={})
-          return request('POST', '/Carrier/', params)
+          return request('POST', "/Carrier/", params)
       end
-
+      
       def get_carrier(params={})
           carrier_id = params.delete('carrier_id')
-          return request('GET', '/Carrier/#{carrier_id}/')
+          return request('GET', "/Carrier/#{carrier_id}/")
       end
-
+      
       def modify_carrier(params={})
           carrier_id = params.delete('carrier_id')
-          return request('POST', '/Carrier/#{carrier_id}/', params)
+          return request('POST', "/Carrier/#{carrier_id}/", params)
       end
-
+      
       def delete_carrier(params={})
           carrier_id = params.delete('carrier_id')
-          return request('DELETE', '/Carrier/#{carrier_id}/')
+          return request('DELETE', "/Carrier/#{carrier_id}/")
       end
-
+      
       ## Carrier Routings ##
       def get_carrier_routings(params={})
-          return request('GET', '/CarrierRouting/', params)
+          return request('GET', "/CarrierRouting/", params)
       end
-
+      
       def create_carrier_routing(params={})
-          return request('POST', '/CarrierRouting/', params)
+          return request('POST', "/CarrierRouting/", params)
       end
-
+      
       def get_carrier_routing(params={})
           routing_id = params.delete('routing_id')
-          return request('GET', '/CarrierRouting/#{routing_id}/')
+          return request('GET', "/CarrierRouting/#{routing_id}/")
       end
-
+      
       def modify_carrier_routing(params={})
           routing_id = params.delete('routing_id')
-          return request('POST', '/CarrierRouting/#{routing_id}/', params)
+          return request('POST', "/CarrierRouting/#{routing_id}/", params)
       end
-
+      
       def delete_carrier_routing(params={})
           routing_id = params.delete('routing_id')
-          return request('DELETE', '/CarrierRouting/#{routing_id}/')
+          return request('DELETE', "/CarrierRouting/#{routing_id}/")
       end
-
+      
       ## Message ##
       def send_message(params={})
-          return request('POST', '/Message/', params)
+          return request('POST', "/Message/", params)
       end
   end
 


### PR DESCRIPTION
Numerous methods include single quotes in strings that include ruby variables. They need to be double quotes to work properly.
