### PR TITLE
add method add_a_number_from_your_own_carrier

### DIFF
--- a/lib/plivo.rb
+++ b/lib/plivo.rb
@@ -154,6 +154,10 @@ module Plivo
       return request('GET', "/Number/", params)
     end
     
+    def add_a_number_from_your_own_carrier(params={})
+      return request('POST', "/Number/", params)
+    end
+
     def search_numbers(params={})
       return request('GET', "/AvailableNumber/", params)
     end


### PR DESCRIPTION
Add method to add a number from a carrier: https://plivo.com/docs/api/numbers/number/#carrier_number_add