### PR TITLE
ability to use hash keys for subaccounts

### DIFF
--- a/lib/plivo.rb
+++ b/lib/plivo.rb
@@ -111,17 +111,17 @@ module Plivo
     end
     
     def get_subaccount(params={})
-      subauth_id = params.delete("subauth_id")
+      subauth_id = params.delete("subauth_id") || params.delete(:subauth_id)
       return request('GET', "/Subaccount/#{subauth_id}/", params)
     end
     
     def modify_subaccount(params={})
-      subauth_id = params.delete("subauth_id")
+      subauth_id = params.delete("subauth_id") || params.delete(:subauth_id)
       return request('POST', "/Subaccount/#{subauth_id}/", params)
     end
     
     def delete_subaccount(params={})
-      subauth_id = params.delete("subauth_id")
+      subauth_id = params.delete("subauth_id") || params.delete(:subauth_id)
       return request('DELETE', "/Subaccount/#{subauth_id}/", params)
     end
     


### PR DESCRIPTION
This will allow parameters to be passed by symbols as well as string:

 {subauth_id: "value"}  would become equivalent to {"subauth_id" => "value"} when used.

There are a number of other areas throughout the library in which this may be useful.
