### PR TITLE
inherit from StandardError instead of exception

### DIFF
--- a/lib/plivo.rb
+++ b/lib/plivo.rb
@@ -7,7 +7,7 @@ require 'openssl'
 require 'base64'
 
 module Plivo
-  class PlivoError < Exception
+  class PlivoError < StandardError
   end
 
   class XPlivoSignature


### PR DESCRIPTION
## Background

`Exception` is normally reserved for segfaults and other errors outside of the runtime. Inheriting form `Exception` can potentially interfere with things like SystemExit and interrupts. 

This changes the inheritance of `PlivoError` from `Exception` to `StandardError`.

 [Excellent discussion of this here](http://www.skorks.com/2009/09/ruby-exceptions-and-exception-handling/). 
