### PR TITLE
rename User class to avoid namespace collisions

### DIFF
--- a/lib/plivo.rb
+++ b/lib/plivo.rb
@@ -687,13 +687,13 @@ module Plivo
   end
 
 
-  class User < Element
+  class PlivoUser < Element
     @nestables = []
     @valid_attributes = ['sendDigits', 'sendOnPreanswer', 'sipHeaders']
 
     def initialize(body, attributes={})
       if not body
-        raise PlivoError, 'No user set for User'
+        raise PlivoError, 'No user set for PlivoUser'
       end
       super(body, attributes)
     end
@@ -701,7 +701,7 @@ module Plivo
 
 
   class Dial < Element
-    @nestables = ['Number', 'User']
+    @nestables = ['Number', 'PlivoUser']
     @valid_attributes = ['action','method','timeout','hangupOnStar',
                          'timeLimit','callerId', 'callerName', 'confirmSound',
                          'dialMusic', 'confirmKey', 'redirect',


### PR DESCRIPTION
Background
----

When `Plivo` is used as a mixin (as in all of the examples provided), it pollutes the `User` namespace, which means examples like the following will fail:

```ruby
class DailyMessageWorker
  include Plivo
   def perform
     plivo.send_message({'dst' => user.phone_number,
         #other params    
     })
   end

  def user
    User.where(hour_to_message: Time.now.hour).last
  end

  def plivo
    @plivo ||= RestAPI.new(PLIVO_CONFIG[:auth_id], PLIVO_CONFIG[:auth_token])
  end
end
```

Plivo will probably be used in the context of background workers. A model likely to have phone numbers is the `User` model, which is common to nearly all Rails applications. Hence namespace collisions seem highly likely.

The change herein addresses this issue.
