### PR TITLE
Allow symbols when making requests against the REST API

### DIFF
--- a/lib/plivo.rb
+++ b/lib/plivo.rb
@@ -44,6 +44,14 @@ module Plivo
       return myhash.map { |k, v| "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}" }.join("&")
     end
 
+    def params_filter(params)
+      if defined?(ActiveSupport::HashWithIndifferentAccess)
+        ActiveSupport::HashWithIndifferentAccess.new(params)
+      else
+        params
+      end
+    end
+
     def request(method, path, params=nil)
       if method == "POST"
         if not params
@@ -95,228 +103,274 @@ module Plivo
 
     ## Accounts ##
     def get_account(params={})
+      params = params_filter(params)
       return request('GET', "/", params)
     end
 
     def modify_account(params={})
+      params = params_filter(params)
       return request('POST', "/", params)
     end
 
     def get_subaccounts(params={})
+      params = params_filter(params)
       return request('GET', "/Subaccount/", params)
     end
 
     def create_subaccount(params={})
+      params = params_filter(params)
       return request('POST', "/Subaccount/", params)
     end
 
     def get_subaccount(params={})
+      params = params_filter(params)
       subauth_id = params.delete("subauth_id") || params.delete(:subauth_id)
       return request('GET', "/Subaccount/#{subauth_id}/", params)
     end
 
     def modify_subaccount(params={})
+      params = params_filter(params)
       subauth_id = params.delete("subauth_id") || params.delete(:subauth_id)
       return request('POST', "/Subaccount/#{subauth_id}/", params)
     end
 
     def delete_subaccount(params={})
+      params = params_filter(params)
       subauth_id = params.delete("subauth_id") || params.delete(:subauth_id)
       return request('DELETE', "/Subaccount/#{subauth_id}/", params)
     end
 
     ## Applications ##
     def get_applications(params={})
+      params = params_filter(params)
       return request('GET', "/Application/", params)
     end
 
     def create_application(params={})
+      params = params_filter(params)
       return request('POST', "/Application/", params)
     end
 
     def get_application(params={})
+      params = params_filter(params)
       app_id = params.delete("app_id")
       return request('GET', "/Application/#{app_id}/", params)
     end
 
     def modify_application(params={})
+      params = params_filter(params)
       app_id = params.delete("app_id")
       return request('POST', "/Application/#{app_id}/", params)
     end
 
     def delete_application(params={})
+      params = params_filter(params)
       app_id = params.delete("app_id")
       return request('DELETE', "/Application/#{app_id}/", params)
     end
 
     ## Numbers ##
     def get_numbers(params={})
+      params = params_filter(params)
       return request('GET', "/Number/", params)
     end
 
     def search_numbers(params={})
+      params = params_filter(params)
       return request('GET', "/AvailableNumber/", params)
     end
 
     def get_number(params={})
+      params = params_filter(params)
       number = params.delete("number")
       return request('GET', "/Number/#{number}/", params)
     end
 
     def rent_number(params={})
+      params = params_filter(params)
       number = params.delete("number")
       return request('POST', "/AvailableNumber/#{number}/", params)
     end
 
     def unrent_number(params={})
+      params = params_filter(params)
       number = params.delete("number")
       return request('DELETE', "/Number/#{number}/", params)
     end
 
     def link_application_number(params={})
+      params = params_filter(params)
       number = params.delete("number")
       return request('POST', "/Number/#{number}/", params)
     end
 
     def unlink_application_number(params={})
+      params = params_filter(params)
       number = params.delete("number")
       params = {"app_id" => ""}
       return request('POST', "/Number/#{number}/", params)
     end
 
     def get_number_group(params={})
+      params = params_filter(params)
       return request('GET', "/AvailableNumberGroup/", params)
     end
 
     def get_number_group_details(params={})
+      params = params_filter(params)
       group_id = params.delete('group_id')
       return request('GET', "/AvailableNumberGroup/#{group_id}/", params)
     end
 
     def rent_from_number_group(params={})
+      params = params_filter(params)
       group_id = params.delete('group_id')
       return request('POST', "/AvailableNumberGroup/#{group_id}/", params)
     end
 
     ## Calls ##
     def get_cdrs(params={})
+      params = params_filter(params)
       return request('GET', "/Call/", params)
     end
 
     def get_cdr(params={})
+      params = params_filter(params)
       record_id = params.delete('record_id')
       return request('GET', "/Call/#{record_id}/", params)
     end
 
     def get_live_calls(params={})
+      params = params_filter(params)
       params["status"] = "live"
       return request('GET', "/Call/", params)
     end
 
     def get_live_call(params={})
+      params = params_filter(params)
       call_uuid = params.delete('call_uuid')
       params["status"] = "live"
       return request('GET', "/Call/#{call_uuid}/", params)
     end
 
     def make_call(params={})
+      params = params_filter(params)
       return request('POST', "/Call/", params)
     end
 
     def hangup_all_calls(params={})
+      params = params_filter(params)
       return request('DELETE', "/Call/", params)
     end
 
     def transfer_call(params={})
+      params = params_filter(params)
       call_uuid = params.delete('call_uuid')
       return request('POST', "/Call/#{call_uuid}/", params)
     end
 
     def hangup_call(params={})
+      params = params_filter(params)
       call_uuid = params.delete('call_uuid')
       return request('DELETE', "/Call/#{call_uuid}/", params)
     end
 
     def record(params={})
+      params = params_filter(params)
       call_uuid = params.delete('call_uuid')
       return request('POST', "/Call/#{call_uuid}/Record/", params)
     end
 
     def stop_record(params={})
+      params = params_filter(params)
       call_uuid = params.delete('call_uuid')
       return request('DELETE', "/Call/#{call_uuid}/Record/", params)
     end
 
     def play(params={})
+      params = params_filter(params)
       call_uuid = params.delete('call_uuid')
       return request('POST', "/Call/#{call_uuid}/Play/", params)
     end
 
     def stop_play(params={})
+      params = params_filter(params)
       call_uuid = params.delete('call_uuid')
       return request('DELETE', "/Call/#{call_uuid}/Play/", params)
     end
 
     def speak(params={})
+      params = params_filter(params)
       call_uuid = params.delete('call_uuid')
       params.update({"text" => HTMLEntities.new(:html4).encode(params['text'], :decimal)})
       return request('POST', "/Call/#{call_uuid}/Speak/", params)
     end
 
     def stop_speak(params={})
+      params = params_filter(params)
       call_uuid = params.delete('call_uuid')
       return request('DELETE', "/Call/#{call_uuid}/Speak/", params)
     end
 
     def send_digits(params={})
+      params = params_filter(params)
       call_uuid = params.delete('call_uuid')
       return request('POST', "/Call/#{call_uuid}/DTMF/", params)
     end
 
     ## Calls requests ##
     def hangup_request(params={})
+      params = params_filter(params)
       request_uuid = params.delete('request_uuid')
       return request('DELETE', "/Request/#{request_uuid}/", params)
     end
 
     ## Conferences ##
     def get_live_conferences(params={})
+      params = params_filter(params)
       return request('GET', "/Conference/", params)
     end
 
     def hangup_all_conferences(params={})
+      params = params_filter(params)
       return request('DELETE', "/Conference/", params)
     end
 
     def get_live_conference(params={})
+      params = params_filter(params)
       conference_name = params.delete('conference_name')
       return request('GET', "/Conference/#{conference_name}/", params)
     end
 
     def hangup_conference(params={})
+      params = params_filter(params)
       conference_name = params.delete('conference_name')
       return request('DELETE', "/Conference/#{conference_name}/", params)
     end
 
     def hangup_member(params={})
+      params = params_filter(params)
       conference_name = params.delete('conference_name')
       member_id = params.delete('member_id')
       return request('DELETE', "/Conference/#{conference_name}/Member/#{member_id}/", params)
     end
 
     def play_member(params={})
+      params = params_filter(params)
       conference_name = params.delete('conference_name')
       member_id = params.delete('member_id')
       return request('POST', "/Conference/#{conference_name}/Member/#{member_id}/Play/", params)
     end
 
     def stop_play_member(params={})
+      params = params_filter(params)
       conference_name = params.delete('conference_name')
       member_id = params.delete('member_id')
       return request('DELETE', "/Conference/#{conference_name}/Member/#{member_id}/Play/", params)
     end
 
     def speak_member(params={})
+      params = params_filter(params)
       conference_name = params.delete('conference_name')
       member_id = params.delete('member_id')
       params.update({"text" => HTMLEntities.new(:html4).encode(params['text'], :decimal)})
@@ -324,158 +378,189 @@ module Plivo
     end
 
     def deaf_member(params={})
+      params = params_filter(params)
       conference_name = params.delete('conference_name')
       member_id = params.delete('member_id')
       return request('POST', "/Conference/#{conference_name}/Member/#{member_id}/Deaf/", params)
     end
 
     def undeaf_member(params={})
+      params = params_filter(params)
       conference_name = params.delete('conference_name')
       member_id = params.delete('member_id')
       return request('DELETE', "/Conference/#{conference_name}/Member/#{member_id}/Deaf/", params)
     end
 
     def mute_member(params={})
+      params = params_filter(params)
       conference_name = params.delete('conference_name')
       member_id = params.delete('member_id')
       return request('POST', "/Conference/#{conference_name}/Member/#{member_id}/Mute/", params)
     end
 
     def unmute_member(params={})
+      params = params_filter(params)
       conference_name = params.delete('conference_name')
       member_id = params.delete('member_id')
       return request('DELETE', "/Conference/#{conference_name}/Member/#{member_id}/Mute/", params)
     end
 
     def kick_member(params={})
+      params = params_filter(params)
       conference_name = params.delete('conference_name')
       member_id = params.delete('member_id')
       return request('POST', "/Conference/#{conference_name}/Member/#{member_id}/Kick/", params)
     end
 
     def record_conference(params={})
+      params = params_filter(params)
       conference_name = params.delete('conference_name')
       return request('POST', "/Conference/#{conference_name}/Record/", params)
     end
 
     def stop_record_conference(params={})
+      params = params_filter(params)
       conference_name = params.delete('conference_name')
       return request('DELETE', "/Conference/#{conference_name}/Record/", params)
     end
 
     ## Recordings ##
     def get_recordings(params={})
+      params = params_filter(params)
       return request('GET', "/Recording/", params)
     end
 
     def get_recording(params={})
+      params = params_filter(params)
       recording_id = params.delete('recording_id')
       return request('GET', "/Recording/#{recording_id}/", params)
     end
 
     def delete_recording(params={})
+      params = params_filter(params)
       recording_id = params.delete('recording_id')
       return request('DELETE', "/Recording/#{recording_id}/", params)
     end
 
     ## Endpoints ##
     def get_endpoints(params={})
+      params = params_filter(params)
       return request('GET', "/Endpoint/", params)
     end
 
     def create_endpoint(params={})
+      params = params_filter(params)
       return request('POST', "/Endpoint/", params)
     end
 
     def get_endpoint(params={})
+      params = params_filter(params)
       endpoint_id = params.delete('endpoint_id')
       return request('GET', "/Endpoint/#{endpoint_id}/", params)
     end
 
     def modify_endpoint(params={})
+      params = params_filter(params)
       endpoint_id = params.delete('endpoint_id')
       return request('POST', "/Endpoint/#{endpoint_id}/", params)
     end
 
     def delete_endpoint(params={})
+      params = params_filter(params)
       endpoint_id = params.delete('endpoint_id')
       return request('DELETE', "/Endpoint/#{endpoint_id}/", params)
     end
 
     ## Incoming Carriers ##
     def get_incoming_carriers(params={})
+      params = params_filter(params)
       return request('GET', "/IncomingCarrier/", params)
     end
 
     def create_incoming_carrier(params={})
+      params = params_filter(params)
       return request('POST', "/IncomingCarrier/", params)
     end
 
     def get_incoming_carrier(params={})
+      params = params_filter(params)
       carrier_id = params.delete('carrier_id')
       return request('GET', "/IncomingCarrier/#{carrier_id}/", params)
     end
 
     def modify_incoming_carrier(params={})
+      params = params_filter(params)
       carrier_id = params.delete('carrier_id')
       return request('POST', "/IncomingCarrier/#{carrier_id}/", params)
     end
 
     def delete_incoming_carrier(params={})
+      params = params_filter(params)
       carrier_id = params.delete('carrier_id')
       return request('DELETE', "/IncomingCarrier/#{carrier_id}/", params)
     end
 
     ## Outgoing Carriers ##
     def get_outgoing_carriers(params={})
+      params = params_filter(params)
       return request('GET', "/OutgoingCarrier/", params)
     end
 
     def create_outgoing_carrier(params={})
+      params = params_filter(params)
       return request('POST', "/OutgoingCarrier/", params)
     end
 
     def get_outgoing_carrier(params={})
+      params = params_filter(params)
       carrier_id = params.delete('carrier_id')
       return request('GET', "/OutgoingCarrier/#{carrier_id}/", params)
     end
 
     def modify_outgoing_carrier(params={})
+      params = params_filter(params)
       carrier_id = params.delete('carrier_id')
       return request('POST', "/OutgoingCarrier/#{carrier_id}/", params)
     end
 
     def delete_outgoing_carrier(params={})
+      params = params_filter(params)
       carrier_id = params.delete('carrier_id')
       return request('DELETE', "/OutgoingCarrier/#{carrier_id}/", params)
     end
 
     ## Outgoing Carrier Routings ##
     def get_outgoing_carrier_routings(params={})
+      params = params_filter(params)
       return request('GET', "/OutgoingCarrierRouting/", params)
     end
 
     def create_outgoing_carrier_routing(params={})
+      params = params_filter(params)
       return request('POST', "/OutgoingCarrierRouting/", params)
     end
 
     def get_outgoing_carrier_routing(params={})
+      params = params_filter(params)
       routing_id = params.delete('routing_id')
       return request('GET', "/OutgoingCarrierRouting/#{routing_id}/", params)
     end
 
     def modify_outgoing_carrier_routing(params={})
+      params = params_filter(params)
       routing_id = params.delete('routing_id')
       return request('POST', "/OutgoingCarrierRouting/#{routing_id}/", params)
     end
 
     def delete_outgoing_carrier_routing(params={})
+      params = params_filter(params)
       routing_id = params.delete('routing_id')
       return request('DELETE', "/OutgoingCarrierRouting/#{routing_id}/", params)
     end
 
     ## Pricing ##
     def pricing(params={})
+      params = params_filter(params)
       return request('GET', "/Pricing/", params)
     end
 
@@ -485,14 +570,17 @@ module Plivo
 
     ## Message ##
     def send_message(params={})
+      params = params_filter(params)
       return request('POST', "/Message/", params)
     end
 
     def get_messages(params={})
+      params = params_filter(params)
       return request('GET', "/Message/", params)
     end
 
     def get_message(params={})
+      params = params_filter(params)
       record_id = params.delete('record_id')
       return request('GET', "/Message/#{record_id}/", params)
     end

--- a/plivo.gemspec
+++ b/plivo.gemspec
@@ -11,9 +11,9 @@ Gem::Specification.new do |s|
   s.files = Dir['lib/*']
   s.has_rdoc = true
   s.extra_rdoc_files = ['README.md']
-  s.add_dependency('builder', '~> 2.1', '>= 2.1.2')
-  s.add_dependency('rest-client', '~> 1.6', '>= 1.6.7')
-  s.add_dependency('json', '~> 1.6', '>= 1.6.6')
-  s.add_dependency('htmlentities', '~> 4.3', '>= 4.3.1')
+  s.add_dependency('builder', '>= 2.1.2')
+  s.add_dependency('rest-client', '>= 1.6.7')
+  s.add_dependency('json', '>= 1.6.6')
+  s.add_dependency('htmlentities', '>= 4.3.1')
   s.extensions = 'ext/mkrf_conf.rb'
 end


### PR DESCRIPTION
If activesupport is installed use it to allow symbols or strings when making REST API calls.