### PR TITLE
Add digitsMatchBLeg parameter to Dial XML

### DIFF
--- a/lib/plivo.rb
+++ b/lib/plivo.rb
@@ -723,7 +723,7 @@ module Plivo
         @valid_attributes = ['action','method','timeout','hangupOnStar',
             'timeLimit','callerId', 'callerName', 'confirmSound',
             'dialMusic', 'confirmKey', 'redirect',
-            'callbackUrl', 'callbackMethod', 'digitsMatch',
+            'callbackUrl', 'callbackMethod', 'digitsMatch', 'digitsMatchBLeg',
             'sipHeaders']
 
         def initialize(attributes={}, &block)


### PR DESCRIPTION
Hi!

A new parameter is available (see https://www.plivo.com/docs/xml/dial/) but the Ruby lib was not updated :)

Regards,
Pierre-Baptiste (Aircall).