### PR TITLE
Readme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,21 @@ The Plivo Ruby library simplifies the process of making REST calls and generatin
 See [Plivo Documentation](http://www.plivo.com/docs/) for more information.
 
 
-## GEM Installation
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'plivo'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
 
     $ gem install plivo
-
-
-## Manual Installation
-
-To use the rake command to build the gem and
-
-**Download the source and run:**
-    $ sudo gem install /path/to/plivo/gem
-
-to finish the installation
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See [Plivo Documentation](http://www.plivo.com/docs/) for more information.
 
 ## GEM Installation
 
-    $ sudo gem install plivo
+    $ gem install plivo
 
 
 ## Manual Installation

--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ Or install it yourself as:
 
 ## Usage
 
+Require the library:
+
+```ruby
+require 'plivo'
+```
+
 To use the Plivo Ruby library, you will need to specify the AUTH_ID and AUTH_TOKEN, before you can make REST requests.
 
 See [Plivo Documentation](http://www.plivo.com/docs/) for more information.
-
-## Files
-
-**lib/plivo.rb:** include this library in your code
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,6 @@ Or install it yourself as:
 
     $ gem install plivo
 
-### Requirements
-
-```
-gem "rest-client", "~> 1.6.7"
-gem "json", "~> 1.6.6"
-gem "htmlentities", "~> 4.3.1"
-```
-
 ## Usage
 
 To use the Plivo Ruby library, you will need to specify the AUTH_ID and AUTH_TOKEN, before you can make REST requests.


### PR DESCRIPTION
1. **Don't use `sudo` to install gems.**
   You should **never ever** install gems with sudo, unless you know what you are doing. It messes up the permissions of your local gems. If you need to install them with sudo, you've most likely already broke the permissions of your local gems.
2. You should include installation instructions for bundler - it's a normal convention.
3. No one in the ruby community manually installs gems - there's a large chance that something will go wrong. You don't need a manual installation section.
4. Also, there is no need to include a requirements section - requirements are automatically installed, and people who care about the requirements can always look in the gem spec or on rubygems.org.
5. Instead of a "Files" section, a line of code requiring the gem in the usage section makes it easier to use the library.

Another note, you might want to put build instructions in a contributing section.
