### PR TITLE
Specify dependencies in the gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,4 @@
 source "https://rubygems.org"
 
-gem "builder", ">= 2.1.2"
-gem "rest-client", ">= 1.6.7"
-gem "json", ">= 1.6.6"
-
+# Specify your gem's dependencies in wit_bot.gemspec
+gemspec


### PR DESCRIPTION
This line makes tells bundler gems are specified in the gemspec.

> The gemspec line tells bundler that it can fine a .gemspec file alongside the Gemfile. When you run bundle install, bundler will find the .gemspec and treat the local directory as a local, unpacked gem. It will find and resolve the dependencies listed in the .gemspec. Bundler's runtime will add the load paths listed in the .gemspec to the load path, as well as the load paths of any of the gems listed as dependencies (and so on). So you get to use bundler while developing a gem with no duplication.

[source](http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/)
