### PR TITLE
Gemspec extensions are expected to be an array

### DIFF
--- a/plivo.gemspec
+++ b/plivo.gemspec
@@ -16,5 +16,4 @@ Gem::Specification.new do |s|
   s.add_dependency('json', '~> 1.6', '>= 1.6.6')
   s.add_dependency('htmlentities', '~> 4.3', '>= 4.3.1')
   s.extensions = ['ext/mkrf_conf.rb']
-  s.bindir = 'bin'
 end

--- a/plivo.gemspec
+++ b/plivo.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
   s.add_dependency('rest-client', '~> 1.6', '>= 1.6.7')
   s.add_dependency('json', '~> 1.6', '>= 1.6.6')
   s.add_dependency('htmlentities', '~> 4.3', '>= 4.3.1')
-  s.extensions = 'ext/mkrf_conf.rb'
+  s.extensions = ['ext/mkrf_conf.rb']
   s.bindir = 'bin'
 end


### PR DESCRIPTION
http://guides.rubygems.org/gems-with-extensions/#gem-specification

[fixes #50]