### PR TITLE
fix for travis-ci bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: ruby
+cache: bundler
+bundler_args: --without development
 rvm:
   - ruby-head
   - 2.4.0
@@ -7,4 +9,3 @@ rvm:
   - 2.2.0
   - 2.1
   - 2.0.0
-before_install: gem install bundler -v 1.14.6

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,6 @@ gemspec
 group :test do
   gem 'rake', '~> 10.1'
   gem 'rspec', '~> 3.0'
+  gem 'simplecov'
+  gem 'json'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :test do
+  gem 'rake', '~> 10.1'
+  gem 'rspec', '~> 3.0'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
-require "bundler/gem_tasks"
+require 'bundler'
+Bundler.setup
+Bundler::GemHelper.install_tasks
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)

--- a/plivo.gemspec
+++ b/plivo.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday_middleware', '~> 0.12.2'
   spec.add_dependency 'htmlentities'
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler', '>= 1.14', '<3.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'json'


### PR DESCRIPTION
Forcing an install of bundler on Travis is unnecessary. Travis will
install a version of bundler as required for given ruby version. 