### PR TITLE
Add support for offset and limit to Endpoints#list

### DIFF
--- a/lib/plivo/resources/endpoints.rb
+++ b/lib/plivo/resources/endpoints.rb
@@ -99,8 +99,34 @@ module Plivo
         perform_create(params)
       end
 
-      def list
-        perform_list
+      ##
+      # List all endpoints
+      # @param [Hash] options
+      # @option options [Int] :offset
+      # @option options [Int] :limit
+      # @return [Hash]
+      def list(options=nil)
+        return perform_list if options.nil?
+
+        params = {}
+
+        %i[offset limit].each do |param|
+          if options.key?(param) && valid_param?(param, options[param],
+                                                 [Integer], true)
+            params[param] = options[param]
+          end
+        end
+
+        if options.key?(:limit) && (options[:limit] > 20 || options[:limit] <= 0)
+          raise_invalid_request('The maximum number of results that can be '\
+          "fetched is 20. limit can't be more than 20 or less than 1")
+        end
+
+        if options.key?(:offset) && options[:offset] < 0
+          raise_invalid_request("Offset can't be negative")
+        end
+
+        perform_list(params)
       end
 
       def each


### PR DESCRIPTION
The list method for Endpoints lacks support for offset and limit options. I added them mimicking other resources.