### PR TITLE
support powerpack id filter for list mdr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 
-## [4.18.0](https://github.com/plivo/plivo-ruby/releases/tag/v4.18.0) (2021-07-06)
--  Powerpack ID filter for list MDR
+## [4.18.0](https://github.com/plivo/plivo-ruby/releases/tag/v4.18.0) (2021-07-13)
+- Power pack ID has been included to the response for the [list all messages API](https://www.plivo.com/docs/sms/api/message/list-all-messages/) and the [get message details API](https://www.plivo.com/docs/sms/api/message#retrieve-a-message).
+- Support for filtering messages by Power pack ID has been added to the [list all messages API](https://www.plivo.com/docs/sms/api/message#list-all-messages).
 
 ## [4.17.1](https://github.com/plivo/plivo-ruby/releases/tag/v4.17.1) (2021-06-18)
 - **WARNING**: Remove total_count field from meta data for list MDR response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [4.18.0](https://github.com/plivo/plivo-ruby/releases/tag/v4.18.0) (2021-07-06)
+-  Powerpack ID filter for list MDR
+
 ## [4.17.1](https://github.com/plivo/plivo-ruby/releases/tag/v4.17.1) (2021-06-18)
 - **WARNING**: Remove total_count field from meta data for list MDR response
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add this line to your application's Gemfile:
 
 ```ruby
 
-gem 'plivo', '>= 4.17.1'
+gem 'plivo', '>= 4.18.0'
 
 ```
 

--- a/lib/plivo/resources/messages.rb
+++ b/lib/plivo/resources/messages.rb
@@ -29,6 +29,7 @@ module Plivo
           to_number: @to_number,
           total_amount: @total_amount,
           total_rate: @total_rate,
+          powerpack_id: @powerpack_id,
           units: @units
         }.to_s
       end
@@ -152,8 +153,7 @@ module Plivo
       # @option options [Int] :limit Used to display the number of results per page. The maximum number of results that can be fetched is 20.
       # @option options [Int] :offset Denotes the number of value items by which the results should be offset. Eg:- If the result contains a 1000 values and limit is set to 10 and offset is set to 705, then values 706 through 715 are displayed in the results. This parameter is also used for pagination of the results.
       # @option options [String] :error_code Delivery Response code returned by the carrier attempting the delivery. See Supported error codes {https://www.plivo.com/docs/api/message/#standard-plivo-error-codes}.
-      #@option options[List]: media_urls Minimum one media url should be present in Media urls list to send mms. Maximum allowd 10 media urls inside the list (e.g, media_urls : ['https//example.com/test.jpg', 'https://example.com/abcd.gif'])
-      #@option options[List]: media_ids Minimum one media ids should be present in Media ids list to send mms. Maximum allowd 10 media ids inside the list (e.g, media_ids : ['1fs211ba-355b-11ea-bbc9-02121c1190q7'])
+      # @option options [String] :powerpack_id Filter the results by powerpack id.
       def list(options = nil)
         return perform_list if options.nil?
         valid_param?(:options, options, Hash, true)
@@ -161,7 +161,7 @@ module Plivo
         params = {}
         params_expected = %i[
           subaccount message_time message_time__gt message_time__gte
-          message_time__lt message_time__lte error_code
+          message_time__lt message_time__lte error_code powerpack_id
         ]
         params_expected.each do |param|
           if options.key?(param) &&

--- a/lib/plivo/version.rb
+++ b/lib/plivo/version.rb
@@ -1,3 +1,3 @@
 module Plivo
-  VERSION = "4.17.1".freeze
+  VERSION = "4.18.0".freeze
 end


### PR DESCRIPTION
able to filter list of mdr using powerpack id

sample code:
`require "rubygems"
require "/root/plivo-ruby/lib/plivo.rb"
include Plivo

api = RestClient.new()
  response = api.messages.list(
    limit: 20,
    offset: 0,
    powerpack_id:'15c01cc2-4b9f-4d3b-bd15-3c4b38984cc4'
  )
  puts response[:meta]
  response[:objects].each do |r|
    puts r.to_s
  end`
