### PR TITLE
Make Faraday Dependency Less Restrictive

### DIFF
--- a/lib/plivo/base_client.rb
+++ b/lib/plivo/base_client.rb
@@ -137,7 +137,7 @@ module Plivo
         # DANGER: Basic auth should always come after headers, else
         # The headers will replace the basic_auth
 
-        faraday.basic_auth(auth_id, auth_token)
+        faraday.request(:basic_auth, auth_id, auth_token)
 
         faraday.proxy=@proxy_hash if @proxy_hash
         faraday.response :json, content_type: /\bjson$/
@@ -150,7 +150,7 @@ module Plivo
         # DANGER: Basic auth should always come after headers, else
         # The headers will replace the basic_auth
 
-        faraday.basic_auth(auth_id, auth_token)
+        faraday.request(:basic_auth, auth_id, auth_token)
 
         faraday.proxy=@proxy_hash if @proxy_hash
         faraday.response :json, content_type: /\bjson$/
@@ -163,7 +163,7 @@ module Plivo
         # DANGER: Basic auth should always come after headers, else
         # The headers will replace the basic_auth
 
-        faraday.basic_auth(auth_id, auth_token)
+        faraday.request(:basic_auth, auth_id, auth_token)
 
         faraday.proxy=@proxy_hash if @proxy_hash
         faraday.response :json, content_type: /\bjson$/
@@ -176,7 +176,7 @@ module Plivo
         # DANGER: Basic auth should always come after headers, else
         # The headers will replace the basic_auth
 
-        faraday.basic_auth(auth_id, auth_token)
+        faraday.request(:basic_auth, auth_id, auth_token)
 
         faraday.proxy=@proxy_hash if @proxy_hash
         faraday.response :json, content_type: /\bjson$/
@@ -189,7 +189,7 @@ module Plivo
         # DANGER: Basic auth should always come after headers, else
         # The headers will replace the basic_auth
 
-        faraday.basic_auth(auth_id, auth_token)
+        faraday.request(:basic_auth, auth_id, auth_token)
 
         faraday.proxy=@proxy_hash if @proxy_hash
         faraday.response :json, content_type: /\bjson$/
@@ -202,7 +202,7 @@ module Plivo
         # DANGER: Basic auth should always come after headers, else
         # The headers will replace the basic_auth
 
-        faraday.basic_auth(auth_id, auth_token)
+        faraday.request(:basic_auth, auth_id, auth_token)
 
         faraday.proxy=@proxy_hash if @proxy_hash
         faraday.response :json, content_type: /\bjson$/
@@ -255,7 +255,7 @@ module Plivo
 
           faraday.request :multipart
           faraday.request :url_encoded
-          faraday.basic_auth(auth_id, auth_token)
+          faraday.request(:basic_auth, auth_id, auth_token)
 
           faraday.proxy=@proxy_hash if @proxy_hash
           faraday.response :json, content_type: /\bjson$/

--- a/plivo.gemspec
+++ b/plivo.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency 'faraday', '~> 1.0.1'
-  spec.add_dependency 'faraday_middleware', '~> 1.0.0'
+  spec.add_dependency 'faraday', '~> 1.0'
+  spec.add_dependency 'faraday_middleware', '~> 1.0'
   spec.add_dependency 'htmlentities'
   spec.add_dependency 'jwt'
 


### PR DESCRIPTION
- Makes the faraday dependency less restrictive.
- Updates the Faraday basic auth notation to follow new guidelinea. See [docs](https://lostisland.github.io/faraday/middleware/authentication).