### PR TITLE
Upgrade to Faraday v2

### DIFF
--- a/lib/plivo/base_client.rb
+++ b/lib/plivo/base_client.rb
@@ -1,6 +1,5 @@
 require 'json'
 require 'faraday'
-require 'faraday_middleware'
 
 require_relative 'exceptions'
 require_relative 'utils'
@@ -137,7 +136,7 @@ module Plivo
         # DANGER: Basic auth should always come after headers, else
         # The headers will replace the basic_auth
 
-        faraday.request(:basic_auth, auth_id, auth_token)
+        faraday.request(:authorization, :basic, auth_id, auth_token)
 
         faraday.proxy=@proxy_hash if @proxy_hash
         faraday.response :json, content_type: /\bjson$/
@@ -150,7 +149,7 @@ module Plivo
         # DANGER: Basic auth should always come after headers, else
         # The headers will replace the basic_auth
 
-        faraday.request(:basic_auth, auth_id, auth_token)
+        faraday.request(:authorization, :basic, auth_id, auth_token)
 
         faraday.proxy=@proxy_hash if @proxy_hash
         faraday.response :json, content_type: /\bjson$/
@@ -163,7 +162,7 @@ module Plivo
         # DANGER: Basic auth should always come after headers, else
         # The headers will replace the basic_auth
 
-        faraday.request(:basic_auth, auth_id, auth_token)
+        faraday.request(:authorization, :basic, auth_id, auth_token)
 
         faraday.proxy=@proxy_hash if @proxy_hash
         faraday.response :json, content_type: /\bjson$/
@@ -176,7 +175,7 @@ module Plivo
         # DANGER: Basic auth should always come after headers, else
         # The headers will replace the basic_auth
 
-        faraday.request(:basic_auth, auth_id, auth_token)
+        faraday.request(:authorization, :basic, auth_id, auth_token)
 
         faraday.proxy=@proxy_hash if @proxy_hash
         faraday.response :json, content_type: /\bjson$/
@@ -189,7 +188,7 @@ module Plivo
         # DANGER: Basic auth should always come after headers, else
         # The headers will replace the basic_auth
 
-        faraday.request(:basic_auth, auth_id, auth_token)
+        faraday.request(:authorization, :basic, auth_id, auth_token)
 
         faraday.proxy=@proxy_hash if @proxy_hash
         faraday.response :json, content_type: /\bjson$/
@@ -202,7 +201,7 @@ module Plivo
         # DANGER: Basic auth should always come after headers, else
         # The headers will replace the basic_auth
 
-        faraday.request(:basic_auth, auth_id, auth_token)
+        faraday.request(:authorization, :basic, auth_id, auth_token)
 
         faraday.proxy=@proxy_hash if @proxy_hash
         faraday.response :json, content_type: /\bjson$/
@@ -255,7 +254,7 @@ module Plivo
 
           faraday.request :multipart
           faraday.request :url_encoded
-          faraday.request(:basic_auth, auth_id, auth_token)
+          faraday.request(:authorization, :basic, auth_id, auth_token)
 
           faraday.proxy=@proxy_hash if @proxy_hash
           faraday.response :json, content_type: /\bjson$/

--- a/lib/plivo/resources/call_feedback.rb
+++ b/lib/plivo/resources/call_feedback.rb
@@ -1,6 +1,5 @@
 require 'json'
 require 'faraday'
-require 'faraday_middleware'
 
 module Plivo
   module Resources

--- a/plivo.gemspec
+++ b/plivo.gemspec
@@ -31,8 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency 'faraday', '~> 1.0'
-  spec.add_dependency 'faraday_middleware', '~> 1.0'
+  spec.add_dependency 'faraday', '~> 2.0'
   spec.add_dependency 'htmlentities'
   spec.add_dependency 'jwt'
 


### PR DESCRIPTION
## Description

Faraday v2 includes several security patches and fixes that are not available on v1. This PR introduces the necessary changes to bump from v1 to v2.

## Changes

- Update syntax
- Remove middlewares