### PR TITLE
feat: add number_of_employees field to Profile API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [4.63.3](https://github.com/plivo/plivo-ruby/tree/v4.63.3) (2026-06-10)
+**Feature - Profile API number of employees field support**
+- Added Number of Employees field support to Profile API
+
 ## [4.63.2](https://github.com/plivo/plivo-ruby/tree/v4.63.2) (2026-05-26)
 **Feature - Profile API DBA field support**
 - Added Doing Business As (DBA) field support to Profile API

--- a/lib/plivo/resources/profile.rb
+++ b/lib/plivo/resources/profile.rb
@@ -83,7 +83,8 @@ module Plivo
 
             ##
             # Update a Profile
-            # {'address': {}, 'authorized_contact': {}, 'entity_type':'', 'vertical': '', 'company_name': '', 'website':'', 'business_contact_email':'', 'doing_business_as':''}
+            # {'address': {}, 'authorized_contact': {}, 'entity_type':'', 'vertical': '', 'company_name': '', 'website':'', 'business_contact_email':'', 'doing_business_as':'', 'number_of_employees':''}
+            # number_of_employees is an optional string. Allowed values: BETWEEN_1_AND_10, BETWEEN_11_AND_50, BETWEEN_51_AND_200, BETWEEN_201_AND_500, BETWEEN_501_AND_2000, BETWEEN_2001_AND_10000, MORE_THAN_10001
             def update(profile_uuid, options = nil)
               valid_param?(:options, options, Hash, true)
               perform_action_with_identifier(profile_uuid, "POST", options)

--- a/lib/plivo/version.rb
+++ b/lib/plivo/version.rb
@@ -1,3 +1,3 @@
 module Plivo
-  VERSION = "4.63.2".freeze
+  VERSION = "4.63.3".freeze
 end

--- a/spec/mocks/profileGetResponse.json
+++ b/spec/mocks/profileGetResponse.json
@@ -20,6 +20,7 @@
         "company_name": "ABC Inc",
         "customer_type": "DIRECT",
         "doing_business_as": "ABC DBA",
+        "number_of_employees": "BETWEEN_1_AND_10",
         "ein": "111111111",
         "ein_issuing_country": "US",
         "entity_type": "GOVERNMENT",

--- a/spec/resource_profile_spec.rb
+++ b/spec/resource_profile_spec.rb
@@ -133,7 +133,8 @@ describe 'Profile test' do
                                                 "seniority": "C_LEVEL"
                                             },
                                             business_contact_email: "employee@company.com",
-                                            doing_business_as: "Test DBA"
+                                            doing_business_as: "Test DBA",
+                                            number_of_employees: "BETWEEN_1_AND_10"
                                         }
                                     ))
     
@@ -173,7 +174,8 @@ describe 'Profile test' do
                                 "seniority": "C_LEVEL"
                             },
                             business_contact_email: "employee@company.com",
-                            doing_business_as: "Test DBA"
+                            doing_business_as: "Test DBA",
+                            number_of_employees: "BETWEEN_1_AND_10"
                          })
         end
         it 'update profile' do
@@ -201,7 +203,8 @@ describe 'Profile test' do
                                                   "title": "ugigwc",
                                                   "seniority": "admin"
                                               },
-                                              doing_business_as: "Updated DBA"
+                                              doing_business_as: "Updated DBA",
+                                              number_of_employees: "BETWEEN_11_AND_50"
                                           }
                                       ))
       
@@ -231,7 +234,8 @@ describe 'Profile test' do
                                 "title": "ugigwc",
                                 "seniority": "admin"
                             },
-                            doing_business_as: "Updated DBA"
+                            doing_business_as: "Updated DBA",
+                            number_of_employees: "BETWEEN_11_AND_50"
                            })
           end
 end


### PR DESCRIPTION
## Summary
Adds a new optional `number_of_employees` string field to the Profile (10DLC/A2P account profile) create & update API. This mirrors a backend change in campaign-service where `number_of_employees` was added to the Profile create & update request as an optional string.

The field is added in exactly the same places and style as the recently added `doing_business_as` (DBA) field.

## Details
- No client-side enum validation — the server validates the value (matching `doing_business_as` / `business_contact_email`).
- 7 allowed values are documented (not enforced) in a comment on the resource: `BETWEEN_1_AND_10`, `BETWEEN_11_AND_50`, `BETWEEN_51_AND_200`, `BETWEEN_201_AND_500`, `BETWEEN_501_AND_2000`, `BETWEEN_2001_AND_10000`, `MORE_THAN_10001`.
- Version bumped 4.63.2 -> 4.63.3.
- CHANGELOG entry added.

## Files changed
- `lib/plivo/resources/profile.rb` — documented field in update options comment
- `spec/resource_profile_spec.rb` — added field to create & update test payloads + compare_requests data
- `spec/mocks/profileGetResponse.json` — added field to mock response
- `lib/plivo/version.rb` — 4.63.3
- `CHANGELOG.md` — new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)