### PR TITLE
feat: add compliance_application_id param to phone number buy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [4.63.3](https://github.com/plivo/plivo-ruby/tree/v4.63.3) (2026-06-11)
+**Feature - Compliance application support at number purchase**
+- Added `compliance_application_id` optional parameter to PhoneNumber `buy` method, sent as the `compliance_application_id` API parameter for purchasing regulated numbers that require a linked regulatory compliance application at purchase time
+
 ## [4.63.2](https://github.com/plivo/plivo-ruby/tree/v4.63.2) (2026-05-26)
 **Feature - Profile API DBA field support**
 - Added Doing Business As (DBA) field support to Profile API

--- a/lib/plivo/resources/numbers.rb
+++ b/lib/plivo/resources/numbers.rb
@@ -9,12 +9,13 @@ module Plivo
         super
       end
 
-      def buy(app_id = nil, verification_info = nil, cnam_lookup = nil, ha_enable = nil)
+      def buy(app_id = nil, verification_info = nil, cnam_lookup = nil, ha_enable = nil, compliance_application_id = nil)
         params = {}
         params[:app_id] = app_id unless app_id.nil?
         params[:verification_info] = verification_info unless verification_info.nil?
         params[:cnam_lookup] = cnam_lookup unless cnam_lookup.nil?
         params[:ha_enable] = ha_enable unless ha_enable.nil?
+        params[:compliance_application_id] = compliance_application_id unless compliance_application_id.nil?
         perform_action(nil, 'POST', params, true)
       end
 
@@ -123,10 +124,10 @@ module Plivo
         end
       end
 
-      def buy(number, app_id = nil, verification_info = nil, cnam_lookup = nil, ha_enable = nil)
+      def buy(number, app_id = nil, verification_info = nil, cnam_lookup = nil, ha_enable = nil, compliance_application_id = nil)
         valid_param?(:number, number, [Integer, String, Symbol], true)
         PhoneNumber.new(@_client,
-                        resource_id: number).buy(app_id, verification_info, cnam_lookup, ha_enable)
+                        resource_id: number).buy(app_id, verification_info, cnam_lookup, ha_enable, compliance_application_id)
       end
     end
 

--- a/lib/plivo/version.rb
+++ b/lib/plivo/version.rb
@@ -1,3 +1,3 @@
 module Plivo
-  VERSION = "4.63.2".freeze
+  VERSION = "4.63.3".freeze
 end

--- a/spec/resource_phone_numbers_spec.rb
+++ b/spec/resource_phone_numbers_spec.rb
@@ -1,4 +1,6 @@
 require 'rspec'
+require 'json'
+require 'spec_helper'
 
 describe 'Phone Numbers test' do
   def to_json(phone_number)
@@ -76,6 +78,20 @@ describe 'Phone Numbers test' do
                      method: 'POST',
                      data: {
                        app_id: 'app id'
+                     })
+  end
+
+  it 'buy phone number with compliance application id' do
+    contents = File.read(Dir.pwd + '/spec/mocks/phoneNumberCreateResponse.json')
+    mock(202, JSON.parse(contents))
+    expect(JSON.parse(to_json_buy(@api.phone_numbers
+                                      .buy('909090909090', 'app id', nil, nil, nil, 'compliance_app_id'))))
+      .to eql(JSON.parse(contents))
+    compare_requests(uri: '/v1/Account/MAXXXXXXXXXXXXXXXXXX/PhoneNumber/909090909090/',
+                     method: 'POST',
+                     data: {
+                       app_id: 'app id',
+                       compliance_application_id: 'compliance_app_id'
                      })
   end
 end


### PR DESCRIPTION
## What
Adds an optional trailing `compliance_application_id` parameter to the PhoneNumber `buy` methods (both `PhoneNumber#buy` and the resource-interface `buy(number, ...)`). When provided, it is sent as the `compliance_application_id` API parameter at purchase time.

## Why
Regulated numbers (e.g. India) require an approved regulatory compliance application to be linked at the moment of purchase. Previously `buy` only forwarded `app_id`, `verification_info`, `cnam_lookup`, and `ha_enable`, with no way to associate a compliance application during the buy call. This adds that capability.

The new param is a trailing optional argument, so the change is fully backward-compatible — existing callers are unaffected.

## Testing
- `spec/resource_phone_numbers_spec.rb` buy specs pass, including a new "buy phone number with compliance application id" case.
- Full suite: 212 examples, 3 failures — all 3 are pre-existing, unrelated failures in `spec/resource_phone_number_compliance_spec.rb` that exist on `master` independently of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)