### PR TITLE
feat(tollfree-verification): add optional terms, privacy, opt-in and help parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [4.63.4](https://github.com/plivo/plivo-ruby/tree/v4.63.4) (2026-07-27)
+**Feature - Toll-free verification terms, privacy, opt-in and help fields**
+- Added optional `terms_and_conditions_link`, `privacy_policy_link`, `optin_message` and `help_message` parameters to the toll-free verification create and update methods
+
 ## [4.63.3](https://github.com/plivo/plivo-ruby/tree/v4.63.3) (2026-06-11)
 **Feature - Compliance application support at number purchase**
 - Added `compliance_application_id` optional parameter to PhoneNumber `buy` method, sent as the `compliance_application_id` API parameter for purchasing regulated numbers that require a linked regulatory compliance application at purchase time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [4.63.4](https://github.com/plivo/plivo-ruby/tree/v4.63.4) (2026-07-27)
+## [4.63.4](https://github.com/plivo/plivo-ruby/tree/v4.63.4) (2026-07-28)
 **Feature - Toll-free verification terms, privacy, opt-in and help fields**
 - Added optional `terms_and_conditions_link`, `privacy_policy_link`, `optin_message` and `help_message` parameters to the toll-free verification create and update methods
 

--- a/lib/plivo/resources/tollfree_verification.rb
+++ b/lib/plivo/resources/tollfree_verification.rb
@@ -15,7 +15,7 @@ module Plivo
         valid_param?(:options, options, Hash, true)
 
         params = {}
-        params_expected = %i[ usecase usecase_summary profile_uuid optin_type optin_image_url volume message_sample callback_method callback_url extra_data additional_information ]
+        params_expected = %i[ usecase usecase_summary profile_uuid optin_type optin_image_url volume message_sample callback_method callback_url extra_data additional_information terms_and_conditions_link privacy_policy_link optin_message help_message ]
         params_expected.each do |param|
           if options.key?(param) &&
              valid_param?(param, options[param], [String, Symbol], false)
@@ -41,6 +41,10 @@ module Plivo
           callback_url: @callback_url,
           extra_data: @extra_data,
           additional_information: @additional_information,
+          terms_and_conditions_link: @terms_and_conditions_link,
+          privacy_policy_link: @privacy_policy_link,
+          optin_message: @optin_message,
+          help_message: @help_message,
           message_sample: @message_sample,
           optin_image_url: @optin_image_url,
           optin_type: @optin_type,
@@ -121,8 +125,12 @@ module Plivo
       # @param [String] callback_method
       # @param [String] extra_data
       # @param [String] additional_information
+      # @param [String] terms_and_conditions_link
+      # @param [String] privacy_policy_link
+      # @param [String] optin_message
+      # @param [String] help_message
       # return [TollfreeVerification] TollfreeVerification
-      def create(number, usecase, usecase_summary, profile_uuid, optin_type, optin_image_url, volume, message_sample, callback_url = nil, callback_method = nil, extra_data = nil, additional_information = nil)
+      def create(number, usecase, usecase_summary, profile_uuid, optin_type, optin_image_url, volume, message_sample, callback_url = nil, callback_method = nil, extra_data = nil, additional_information = nil, terms_and_conditions_link = nil, privacy_policy_link = nil, optin_message = nil, help_message = nil)
         valid_param?(:number, number, [String, Symbol], true)
         valid_param?(:usecase, usecase, [String, Symbol], true)
         valid_param?(:usecase_summary, usecase_summary, [String, Symbol], true)
@@ -135,6 +143,10 @@ module Plivo
         valid_param?(:callback_method, callback_method, [String, Symbol], false)
         valid_param?(:extra_data, extra_data, [String, Symbol], false)
         valid_param?(:additional_information, additional_information, [String, Symbol], false)
+        valid_param?(:terms_and_conditions_link, terms_and_conditions_link, [String, Symbol], false)
+        valid_param?(:privacy_policy_link, privacy_policy_link, [String, Symbol], false)
+        valid_param?(:optin_message, optin_message, [String, Symbol], false)
+        valid_param?(:help_message, help_message, [String, Symbol], false)
 
         params = {
         number: number,
@@ -148,7 +160,11 @@ module Plivo
         callback_url: callback_url,
         callback_method: callback_method,
         extra_data: extra_data,
-        additional_information: additional_information
+        additional_information: additional_information,
+        terms_and_conditions_link: terms_and_conditions_link,
+        privacy_policy_link: privacy_policy_link,
+        optin_message: optin_message,
+        help_message: help_message
         }.delete_if { |key, value| value.nil? }
 
         return perform_create(params)

--- a/lib/plivo/version.rb
+++ b/lib/plivo/version.rb
@@ -1,3 +1,3 @@
 module Plivo
-  VERSION = "4.63.3".freeze
+  VERSION = "4.63.4".freeze
 end

--- a/spec/resource_tollfree_verification_spec.rb
+++ b/spec/resource_tollfree_verification_spec.rb
@@ -71,4 +71,55 @@ describe 'TollfreeVerifications test' do
                        method: 'DELETE',
                        data: nil)
   end
+
+  it 'creates a tollfree verification with optional link/message fields' do
+      contents = File.read(Dir.pwd + '/spec/mocks/tollfreeVerificationCreateResponse.json')
+      mock(201, JSON.parse(contents))
+      @api.tollfree_verifications.create(
+        '18888888888', 'PROXY', 'summary text', 'a4c95b2c-a3ce-4dc4-b12c-b0f7b48f6c8c',
+        'VERBAL', 'https://example.com/optin.png', '1,000', 'sample message',
+        'https://example.com/callback', 'POST', 'extra data', 'additional info',
+        'https://example.com/terms', 'https://example.com/privacy',
+        'optin message text', 'help message text')
+      compare_requests(uri: '/v1/Account/MAXXXXXXXXXXXXXXXXXX/TollfreeVerification/',
+                       method: 'POST',
+                       data: {
+                         number: '18888888888',
+                         usecase: 'PROXY',
+                         usecase_summary: 'summary text',
+                         profile_uuid: 'a4c95b2c-a3ce-4dc4-b12c-b0f7b48f6c8c',
+                         optin_type: 'VERBAL',
+                         optin_image_url: 'https://example.com/optin.png',
+                         volume: '1,000',
+                         message_sample: 'sample message',
+                         callback_url: 'https://example.com/callback',
+                         callback_method: 'POST',
+                         extra_data: 'extra data',
+                         additional_information: 'additional info',
+                         terms_and_conditions_link: 'https://example.com/terms',
+                         privacy_policy_link: 'https://example.com/privacy',
+                         optin_message: 'optin message text',
+                         help_message: 'help message text'
+                       })
+  end
+
+  it 'updates a tollfree verification with optional link/message fields' do
+      id = 'SAXXXXXXXXXXXXXXXXXX'
+      contents = File.read(Dir.pwd + '/spec/mocks/tollfreeVerificationUpdateResponse.json')
+      mock(202, JSON.parse(contents))
+      @api.tollfree_verifications.update(id, {
+        terms_and_conditions_link: 'https://example.com/terms',
+        privacy_policy_link: 'https://example.com/privacy',
+        optin_message: 'optin message text',
+        help_message: 'help message text'
+      })
+      compare_requests(uri: '/v1/Account/MAXXXXXXXXXXXXXXXXXX/TollfreeVerification/' + id + '/',
+                       method: 'POST',
+                       data: {
+                         terms_and_conditions_link: 'https://example.com/terms',
+                         privacy_policy_link: 'https://example.com/privacy',
+                         optin_message: 'optin message text',
+                         help_message: 'help message text'
+                       })
+  end
 end


### PR DESCRIPTION
## Summary

Adds four new **optional** parameters to the toll-free verification create and update APIs:

| Parameter | Max length |
|---|---|
| `terms_and_conditions_link` | 2000 |
| `privacy_policy_link` | 2000 |
| `optin_message` | 500 |
| `help_message` | 500 |

## Backward compatibility

All four parameters are optional. Existing calls are unaffected — omitting them produces exactly the same request as before.

## Tests

Existing toll-free verification tests are extended to cover the new parameters on both create and update.