### PR TITLE
feat: add internal flag to Endpoint create params (VT-9534)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [4.63.5](https://github.com/plivo/plivo-ruby/tree/v4.63.5) (2026-07-27)
+**Feature - Internal flag on Endpoint create**
+- Added optional `internal` keyword argument to `EndpointInterface#create` so callers can mark newly created SIP endpoints as internal at creation time. When omitted, wire behavior is unchanged.
+
 ## [4.63.3](https://github.com/plivo/plivo-ruby/tree/v4.63.3) (2026-06-11)
 **Feature - Compliance application support at number purchase**
 - Added `compliance_application_id` optional parameter to PhoneNumber `buy` method, sent as the `compliance_application_id` API parameter for purchasing regulated numbers that require a linked regulatory compliance application at purchase time

--- a/lib/plivo/resources/endpoints.rb
+++ b/lib/plivo/resources/endpoints.rb
@@ -85,7 +85,8 @@ module Plivo
       # @param [String] password
       # @param [String] alias_
       # @param [String] app_id
-      def create(username, password, alias_, app_id = nil)
+      # @param [Boolean] internal
+      def create(username, password, alias_, app_id = nil, internal: nil)
         valid_param?(:username, username, [String, Symbol], true)
         valid_param?(:password, password, [String, Symbol], true)
         valid_param?(:alias, alias_, [String, Symbol], true)
@@ -97,6 +98,11 @@ module Plivo
         }
 
         params[:app_id] = app_id unless app_id.nil?
+
+        unless internal.nil?
+          valid_param?(:internal, internal, [TrueClass, FalseClass], true)
+          params[:internal] = internal
+        end
 
         perform_create(params)
       end

--- a/lib/plivo/version.rb
+++ b/lib/plivo/version.rb
@@ -1,3 +1,3 @@
 module Plivo
-  VERSION = "4.63.3".freeze
+  VERSION = "4.63.5".freeze
 end


### PR DESCRIPTION
## Summary

Adds an optional `internal` keyword argument to `EndpointInterface#create` so callers can mark newly created SIP endpoints as internal at creation time.

## Why

Plivo CX (Contacto) auto-creates a SIP endpoint per AOM during user invite for browser-SDK playback. These internal endpoints currently leak into the customer's Endpoints tab in the console (Pylon #2460), causing confusion, prod alerts (customers try to register the SIP from third-party clients), and a security concern (customer can silently change creds).

The **trace** service already supports an `internal` column on the endpoint model + defaults the List API to exclude internal endpoints (commit `cea50cf` / `d425930` on trace). What's missing is the ability for the auto-create call (Hodor) to actually mark endpoints as `internal=true` at creation time. This SDK change unblocks that.

## Change

- `lib/plivo/resources/endpoints.rb` — added `internal:` optional keyword argument to `EndpointInterface#create`. When `nil` (default), the field is not added to the request params; when explicitly set, it is validated as a boolean and forwarded as the `internal` JSON key.
- `lib/plivo/version.rb` — patch bump `4.63.3` -> `4.63.5` (skipping `4.63.4`, already claimed by another in-flight branch).
- `CHANGELOG.md` — new `4.63.5` entry at the top.

## Backwards-compatibility

`internal` defaults to `nil` and is only serialized when the caller explicitly passes it. Every existing caller sees identical wire behavior. Only callers that explicitly pass `internal: true` opt into the new path.

## Test plan

- [x] `ruby -c lib/plivo/resources/endpoints.rb` clean
- [x] `ruby -c lib/plivo/version.rb` clean
- [ ] Existing endpoint specs pass (`bundle exec rspec spec/resource_endpoints_spec.rb` — to be run in CI)
- [ ] End-to-end sanity: hit `api.plivo.com` create endpoint with `internal: true` from a test account and verify `subscriber.internal = true` on the row (validated separately by the CX team's integration)

## Related

- JIRA: VT-9534
- Reference PR: plivo/plivo-go#250
- Slack: [thread on Pylon #2460]
- Companion PRs across other SDKs: plivo-python, plivo-node, plivo-java, plivo-php, plivo-dotnet (following this pattern)

Generated with [Claude Code](https://claude.com/claude-code)